### PR TITLE
docs: fix simple typo, montior -> monitor

### DIFF
--- a/source/initialization.h
+++ b/source/initialization.h
@@ -86,7 +86,7 @@ int init()
             SDL_Log("Detected resolution: %ix%i\n", display_mode.w, display_mode.h);
         }
 
-        // Fix for multi-montior setups:
+        // Fix for multi-monitor setups:
         SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
 
         app.window = SDL_CreateWindow(GAME_TITLE, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_RESIZABLE);


### PR DESCRIPTION
There is a small typo in source/initialization.h.

Should read `monitor` rather than `montior`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md